### PR TITLE
Fixing iframe responsive

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -154,7 +154,7 @@ nav {
 
 .imagen__inicio {
   width: 100%;
-  height: 100%;
+  /* height: 100%;  Esto deforma las imagenes */
 }
 
 .parrafo__inicio {
@@ -452,4 +452,10 @@ footer {
 
 .redes__sociales a i:hover {
   transform: scale(1.7);
+}
+
+
+.responsive-embed {
+  width: 100%;
+  height: 100%;
 }

--- a/pages/productos.html
+++ b/pages/productos.html
@@ -182,7 +182,7 @@
                 </div>
             </div>
             <div class="video">
-                <iframe width="560" height="315" src="https://www.youtube.com/embed/8Oa9EKaaQdU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                <iframe class="responsive-embed" src="https://www.youtube.com/embed/8Oa9EKaaQdU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
             </div>
         </main>
         <footer>


### PR DESCRIPTION
Luciano:

En la parte del iframe es donde mas se estaba rompiendo. Cuando usas medidas absolutas en pantallas que sean de menor tamano, se empieza a romper. Por eso es que te esta pasando lo que pasa. Revisa el codigo y anda ajustandolo :)

Hay varias formas de arreglarlo:

1. Directamente crear una media query que funcione mejor en lo que respecta a ancho y alto.
2. Usando min: https://developer.mozilla.org/es/docs/Web/CSS/min
3. Usando max. https://developer.mozilla.org/en-US/docs/Web/CSS/max